### PR TITLE
youtube 공식문서 기반 DTO데이터 및 설명을 위한 주석 추가, 보안적 인증키 채널ID config화

### DIFF
--- a/spring_BE/src/main/java/com/example/streaming/config/YoutubeConfig.java
+++ b/spring_BE/src/main/java/com/example/streaming/config/YoutubeConfig.java
@@ -1,0 +1,19 @@
+package com.example.streaming.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+@Configuration
+public class YoutubeConfig {
+
+    @Getter
+    @Value("${youtube.API}")
+    private String apiKey;
+
+    @Getter
+    @Value("#{'${youtube.channel.ids}'.split(',')}")
+    private List<String> channelIds;
+
+}

--- a/spring_BE/src/main/java/com/example/streaming/controller/YoutubeController.java
+++ b/spring_BE/src/main/java/com/example/streaming/controller/YoutubeController.java
@@ -18,11 +18,6 @@ public class YoutubeController {
 
     @GetMapping("/youtube/top-channels")
     public List<ChannelDTO> getTopChannels() {
-        List<String> channelIds = List.of(
-                "UC4rlAVgAK0SGk-yTfe48Qpw", // 진용진
-                "UCsU-I-vHLiaMfV_ceaYz5rQ", // 피식대학
-                "UCekSb5Ik_2vBnKnHwhfF7Rw"  // ENA
-        );
-        return youtubeService.getTopChannels(channelIds);
+        return youtubeService.getTopChannels();
     }
 }

--- a/spring_BE/src/main/java/com/example/streaming/dto/ChannelDTO.java
+++ b/spring_BE/src/main/java/com/example/streaming/dto/ChannelDTO.java
@@ -2,12 +2,18 @@ package com.example.streaming.dto;
 
 import lombok.Data;
 
+import java.time.OffsetDateTime;
+import java.util.List;
+
 @Data
 public class ChannelDTO {
-    private String id;
-    private String title;
-    private String thumbnailUrl;
-    private long subscriberCount;
-
-
+    private String id; // 채널 ID
+    private String title; // 채널 제목
+    private String description; // 채널 설명
+    private OffsetDateTime publishedAt; // 채널 생성일
+    private String thumbnailUrl; // 채널 썸네일
+    private long viewCount; // 영상 총 조회 수
+    private long subscriberCount; // 총 구독자 수
+    private long videoCount; // 총 비디오 업로드 수
+    private List<String> topicCategories; // 주제 카테고리 URL (위키백과?)
 }

--- a/spring_BE/src/main/java/com/example/streaming/service/YoutubeService.java
+++ b/spring_BE/src/main/java/com/example/streaming/service/YoutubeService.java
@@ -1,53 +1,92 @@
 package com.example.streaming.service;
 
+import com.example.streaming.config.YoutubeConfig;
 import com.example.streaming.dto.ChannelDTO;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.time.OffsetDateTime;
 import java.util.*;
 
 @Service
 public class YoutubeService {
 
-    private static final String API_KEY = "AIzaSyCZ-rP_hCgDRP1Wf8KTAAAsqK61fxeSCz0";
-    private static final String BASE_URL = "https://www.googleapis.com/youtube/v3/channels";
+    private final YoutubeConfig config;
 
-    public List<ChannelDTO> getTopChannels(List<String> channelIds) {
-        RestTemplate restTemplate = new RestTemplate();
+    //생성자 주입으로 config 객체 받기
+    //application.properties 에서 설정값을 읽기위함
+    public YoutubeService(YoutubeConfig config) {
+        this.config = config;
+    }
+    
+    public List<ChannelDTO> getTopChannels() {
+        RestTemplate restTemplate = new RestTemplate(); // spring HTTP요청 도구
 
-        String url = UriComponentsBuilder.fromHttpUrl(BASE_URL)
-                .queryParam("part", "snippet,statistics")
-                .queryParam("id", String.join(",", channelIds))
-                .queryParam("key", API_KEY)
-                .toUriString();
+        //youtube Data API 요청 URL을 동적으로 생성
+        String url = UriComponentsBuilder.fromHttpUrl("https://www.googleapis.com/youtube/v3/channels")
+                .queryParam("part", "snippet,statistics,topicDetails") //어떤 정보를 포함할지
+                .queryParam("id", String.join(",", config.getChannelIds())) // 조회할 채널 ID들
+                .queryParam("key", config.getApiKey()) // API키
+                .toUriString(); // StringURL 완성
 
+        //API 호출 (GET 요청으로 JSON 데이터를 받아 Map으로 파싱)
         Map<String, Object> response = restTemplate.getForObject(url, Map.class);
+        
+        //응답 객체에서 "items" 배열 꺼내기
         List<Map<String, Object>> items = (List<Map<String, Object>>) response.get("items");
 
+        //최종 결과 저장을 위한 리스트
         List<ChannelDTO> results = new ArrayList<>();
 
+        // 지정한 채널 정보를 순회하면서 DTO에 담기
         for (Map<String, Object> item : items) {
+            //공식문서에 적혀있는 필요한 정보 꺼내기
             Map<String, Object> snippet = (Map<String, Object>) item.get("snippet");
             Map<String, Object> statistics = (Map<String, Object>) item.get("statistics");
             Map<String, Object> thumbnails = (Map<String, Object>) ((Map<String, Object>) snippet.get("thumbnails")).get("default");
+            Map<String, Object> topicDetails = (Map<String, Object>) item.get("topicDetails");
 
+            //채널 하나의 정보를 담을 DTO 객체 생성
             ChannelDTO dto = new ChannelDTO();
+
+            //기본 정보 세팅
             dto.setId((String) item.get("id"));
             dto.setTitle((String) snippet.get("title"));
+            dto.setDescription((String) snippet.get("description"));
+
+            //공식문서에 날짜 ISO 8601 형식이니 offsetDateTime 으로 파싱
+            if (snippet.get("publishedAt") != null) {
+                dto.setPublishedAt(OffsetDateTime.parse((String) snippet.get("publishedAt")));
+            }
             dto.setThumbnailUrl((String) thumbnails.get("url"));
 
-            if (statistics.get("subscriberCount") != null) {
-                dto.setSubscriberCount(Long.parseLong((String) statistics.get("subscriberCount")));
-            } else {
-                dto.setSubscriberCount(0L);
+            //통계 정보는 문자열로 오기 때문에 미리 long 으로 변환
+            dto.setSubscriberCount(parseLongSafe(statistics.get("subscriberCount")));
+            dto.setViewCount(parseLongSafe(statistics.get("viewCount")));
+            dto.setVideoCount(parseLongSafe(statistics.get("videoCount")));
+
+            //topicDetails(위키백과?) 항목이 존재할 경우 카테고리 정보 세팅
+            if (topicDetails != null && topicDetails.get("topicCategories") instanceof List) {
+                dto.setTopicCategories((List<String>) topicDetails.get("topicCategories"));
             }
 
+            //하나의 채널 정보를 리스트에 추가함
             results.add(dto);
         }
 
-        // 구독자 수 내림차순 정렬
+        //구독자 수 시준으로 내림차순 정렬
         results.sort(Comparator.comparingLong(ChannelDTO::getSubscriberCount).reversed());
+
         return results;
+    }
+
+    // 문자열 형태로 온 숫자들을 long 타입으로 파싱하는 함수
+    private long parseLongSafe(Object value) {
+        try {
+            return value != null ? Long.parseLong(value.toString()) : 0L;
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
     }
 }

--- a/spring_BE/src/main/resources/application.properties
+++ b/spring_BE/src/main/resources/application.properties
@@ -1,3 +1,9 @@
+#youtubeAPI ???
+youtube.API=AIzaSyCZ-rP_hCgDRP1Wf8KTAAAsqK61fxeSCz0
+
+#?? ID ??("," ??)
+youtube.channel.ids=UC4rlAVgAK0SGk-yTfe48Qpw,UCsU-I-vHLiaMfV_ceaYz5rQ,UCekSb5Ik_2vBnKnHwhfF7Rw
+
 spring.application.name=streaming
 
 spring.devtools.restart.enabled=true


### PR DESCRIPTION
**description**

### 1. 유튜브에서 제공하는 공식 문서를 기반으로 필요한 데이터들을 추가함
NULL 값은 0으로 초기화
**추가 데이터 리스트**
- 채널 ID
- 채널 제목
- 채널 설명
- 채널 생성일
- 채널 썸네일
- 영상 총 조회수
- 총 구독자 수
- 총 비디오 업로드 수(영상 수)
- 주제 카테고리 URL (위키백과에 설명이 들어간 URL같음)

### 2. 인증 KEY, 테스트를 위한 채널 ID등 보안을 위해 config 구현
설정 값에 지정해두고 config구현 뒤 get함수로 가져오기 구현

